### PR TITLE
fix: correct `target="_blank"` in links

### DIFF
--- a/src/components/AnchorButton.astro
+++ b/src/components/AnchorButton.astro
@@ -9,7 +9,7 @@ interface Props {
 const { class: className, ...rest } = Astro.props;
 ---
 
-<a class:list={["anchor-button", Astro.props.class]} target="blank" {...rest}>
+<a class:list={["anchor-button", Astro.props.class]} target="_blank" {...rest}>
 	<slot />
 </a>
 


### PR DESCRIPTION
## Overview

- Fixes #84

To open links in new tabs, the target must be set to `_blank`.

When using just `blank` (with no underscore), the browser will open a new tab the first time you click on a link, it will internally give it the name "blank", and all other links will be opened in the same tab rather than in new ones.