### PR TITLE
feat: add FAQ for being a dry conference

### DIFF
--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -17,7 +17,7 @@ const faqs: FAQSection[] = [
 			["How big is SquiggleConf?", "We're targeting 250 total attendees."],
 			[
 				"Will there be alcohol at SquiggleConf?",
-				'No. We will act as a "dry" conference (no alcohol).',
+				"There will be no alcohol during the SquiggleConf talks or workshops.",
 			],
 		],
 	],

--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -13,7 +13,13 @@ type FAQSection = [string, [string, string][]];
 const faqs: FAQSection[] = [
 	[
 		"General",
-		[["How big is SquiggleConf?", "We're targeting 250 total attendees."]],
+		[
+			["How big is SquiggleConf?", "We're targeting 250 total attendees."],
+			[
+				"Will there be alcohol at SquiggleConf?",
+				'No. We will act as a "dry" conference (no alcohol).',
+			],
+		],
 	],
 	[
 		"Schedule",


### PR DESCRIPTION
## Overview

Adds a _General_ FAQ entry to `/faqs`.