### PR TITLE
fix: stretch html to min-height: 100%

### DIFF
--- a/src/layouts/base.css
+++ b/src/layouts/base.css
@@ -58,6 +58,10 @@
 		--widthBodyPadding: clamp(1rem, 5vw, 2rem);
 	}
 
+	html {
+		min-height: 100%;
+	}
+
 	html.dark {
 		color-scheme: dark;
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #87
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/SquiggleConf/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/SquiggleConf/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes the `<html>` take up _at least_ 100% of its parent, the viewport. This should stop vertical background cropping on big and/or zoomed-out screens.

💖 