### PR TITLE
fix: hide details marker on hamburger menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -77,6 +77,10 @@
 			var(--transitionMedium) text-shadow;
 	}
 
+	summary::-webkit-details-marker {
+		display: none;
+	}
+
 	details[open] summary {
 		color: var(--colorEmphasizedBackground);
 		text-shadow: 0 0 3px var(--colorOffWhite);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to SquiggleConf! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #128
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/SquiggleConf/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/SquiggleConf/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This hides the little details/summary arrow that was showing up on mobile iOS browsers (chrome, firefox, and safari).

Fixed on mobile now:
![IMG_2150](https://github.com/user-attachments/assets/dce4d493-f130-42ba-8bc1-7402c5c9a1b2)



Verified nothing regressed on desktop: https://jam.dev/c/a166172d-8567-49dd-b400-ca56264aa73d

Keyboard accessibility still works: https://jam.dev/c/d0b22ce5-a1d6-417a-b8a1-52f59eb83c4c


🍔 